### PR TITLE
fix: declare nullable parameters explicitly for PHP 8.4

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -20,7 +20,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>3.0.0</version>
+    <version>3.0.1</version>
     <authors>
         <author>
             <name></name>

--- a/Model/BlockGroup.php
+++ b/Model/BlockGroup.php
@@ -34,7 +34,7 @@ class BlockGroup extends BaseBlockGroup
      *
      * @return bool
      */
-    public function preSave(ConnectionInterface $con = null): bool
+    public function preSave(?ConnectionInterface $con = null): bool
     {
         if (null === $this->getSlug()) {
             $this->setSlug($this->slugify($this->getTitle()));

--- a/TheliaBlocks.php
+++ b/TheliaBlocks.php
@@ -38,7 +38,7 @@ class TheliaBlocks extends BaseModule
     public const FOLDER_LINK = 'folder_link';
     public const CONTENT_LINK = 'content_link';
 
-    public function update($currentVersion, $newVersion, ConnectionInterface $con = null): void
+    public function update($currentVersion, $newVersion, ?ConnectionInterface $con = null): void
     {
         $finder = Finder::create()
             ->name('*.sql')
@@ -56,7 +56,7 @@ class TheliaBlocks extends BaseModule
         }
     }
 
-    public function preActivation(ConnectionInterface $con = null): bool
+    public function preActivation(?ConnectionInterface $con = null): bool
     {
         if (!$this->getConfigValue('is_initialized', false)) {
             $database = new Database($con);
@@ -118,7 +118,7 @@ class TheliaBlocks extends BaseModule
             ->autoconfigure(true);
     }
 
-    public function postActivation(ConnectionInterface $con = null): void
+    public function postActivation(?ConnectionInterface $con = null): void
     {
         ShortCode::createNewShortCodeIfNotExist(self::BLOCK_GROUP_SHORT_CODE, self::BLOCK_GROUP_SHORT_CODE);
         ShortCode::createNewShortCodeIfNotExist(self::ADMIN_CSS_SHORTCODE, self::ADMIN_CSS_SHORTCODE);


### PR DESCRIPTION
## Why

On PHP 8.4, declaring a parameter with a non-nullable type and a `null` default
(`function f(Foo $bar = null)`) is deprecated: *"Implicitly marking parameter
$bar as nullable is deprecated, specify `?Foo` explicitly"*.

The Flexy theme CI runs on PHP 8.3 **and** 8.4; the 8.4 leg reported 21 such
deprecations across the module set, none from the core nor the theme.

## What

Each affected parameter is rewritten as an explicit `?Type $x = null`.

## Impact

None functionally. `Foo $bar = null` and `?Foo $bar = null` describe the exact
same accepted type set, on 8.3 as on 8.4 — the change only makes the nullability
explicit so 8.4 stops emitting the notice. No behaviour, no call site, no
signature compatibility changes.

The overridden lifecycle methods of `Thelia\Module\BaseModule` already declare
`?ConnectionInterface $con = null` in the core, so these overrides now match the
parent exactly instead of relying on the implicit coercion.

Patch version bump so the fix reaches installed setups.
